### PR TITLE
Reverse optimal TTK crit rollback

### DIFF
--- a/src/weapons/ttk_calc.rs
+++ b/src/weapons/ttk_calc.rs
@@ -169,7 +169,7 @@ pub fn calc_ttk(_weapon: &Weapon, _overshield: f64) -> Vec<ResillienceSummary> {
         let mut opt_timeline_headshots = opt_headshots;
 
         // walk back and turn headshots to bodyshots
-        for timeline_snapshot in opt_bullet_timeline.iter().rev() {
+        for timeline_snapshot in opt_bullet_timeline.iter() {
             let _body_damage = timeline_snapshot.0;
             let headshot_diff = timeline_snapshot.1;
 


### PR DESCRIPTION
Fixes targetlock's and precision instrument's optimal TTK calc.
One line change. A lot of possible consequences. 