### PR TITLE
chore: fix sword logic in pvp

### DIFF
--- a/src/perks/year_6_perks.rs
+++ b/src/perks/year_6_perks.rs
@@ -483,10 +483,12 @@ pub fn year_6_perks() {
     add_dmr(
         Perks::SwordLogic,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
-            let buff = match _input.value {
-                0 => 1.0,
-                1..=3 => 1.05 + (0.1 * _input.value as f64),
-                4.. => 1.5,
+            let buff = match (_input.pvp, _input.value) {
+                (_, 0) => 1.0,
+                (false, 1..=3) => 1.05 + (0.1 * _input.value as f64),
+                (false, 4..) => 1.5,
+                (true, 1|2) => 1.2,
+                (true, 3..) => 1.35,
             };
             DamageModifierResponse {
                 impact_dmg_scale: buff,

--- a/src/perks/year_6_perks.rs
+++ b/src/perks/year_6_perks.rs
@@ -487,7 +487,7 @@ pub fn year_6_perks() {
                 (_, 0) => 1.0,
                 (false, 1..=3) => 1.05 + (0.1 * _input.value as f64),
                 (false, 4..) => 1.5,
-                (true, 1|2) => 1.2,
+                (true, 1 | 2) => 1.2,
                 (true, 3..) => 1.35,
             };
             DamageModifierResponse {


### PR DESCRIPTION
apparently sword logic is different in pvp than pve for 2x ... 25% -> 20%. 3x remains the same at 35%