### PR TITLE
fix: path of burning steps to be solar only

### DIFF
--- a/build_resources/cached_build.ron
+++ b/build_resources/cached_build.ron
@@ -1,5 +1,5 @@
 (
-    last_manifest_version: "119016.23.09.18.1805-1-bnet.52208",
+    last_manifest_version: "119105.23.09.20.1915-2-bnet.52254",
     dim_perk_mappings: [
         (23371658, 2551157718),
         (64866129, 3038247973),

--- a/src/perks/buff_perks.rs
+++ b/src/perks/buff_perks.rs
@@ -105,7 +105,12 @@ pub fn buff_perks() {
     add_dmr(
         Perks::PathOfTheBurningSteps,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
-            let buff = surge_buff(_input.cached_data, _input.value, _input.pvp);
+            let buff =
+                if _input.value > 0 && matches!(_input.calc_data.damage_type, DamageType::SOLAR) {
+                    surge_buff(_input.cached_data, _input.value, _input.pvp)
+                } else {
+                    1.0
+                };
             DamageModifierResponse {
                 impact_dmg_scale: buff,
                 explosive_dmg_scale: buff,

--- a/src/perks/buff_perks.rs
+++ b/src/perks/buff_perks.rs
@@ -105,12 +105,10 @@ pub fn buff_perks() {
     add_dmr(
         Perks::PathOfTheBurningSteps,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
-            let buff =
-                if _input.value > 0 && matches!(_input.calc_data.damage_type, DamageType::SOLAR) {
-                    surge_buff(_input.cached_data, _input.value, _input.pvp)
-                } else {
-                    1.0
-                };
+            if _input.value == 0 || _input.calc_data.damage_type != &DamageType::SOLAR {
+                return DamageModifierResponse::default();
+            }
+            let buff = surge_buff(_input.cached_data, _input.value, _input.pvp);
             DamageModifierResponse {
                 impact_dmg_scale: buff,
                 explosive_dmg_scale: buff,


### PR DESCRIPTION
adjusts path of burning steps to apply for solar weapons only instead of all weapons like it does now.

Closes #59 