### PR TITLE
Fix: extra damage falloff start being added to Hunter's Trace

### DIFF
--- a/src/perks/exotic_perks.rs
+++ b/src/perks/exotic_perks.rs
@@ -116,17 +116,6 @@ pub fn exotic_perks() {
         ),
     );
 
-    add_rmr(
-        Perks::HuntersTrace,
-        Box::new(|_input: ModifierResponseInput| -> RangeModifierResponse {
-            let range_ads_scale = if _input.value > 0 { 4.5 / 1.7 } else { 1.0 };
-            RangeModifierResponse {
-                range_zoom_scale: range_ads_scale,
-                ..Default::default()
-            }
-        }),
-    );
-
     add_dmr(
         Perks::MementoMori,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {

--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -412,7 +412,6 @@ pub enum Perks {
     MementoMori = 647617635,
     AgersScepterCatalyst = 970163821,
     Broadhead = 2287699930,
-    HuntersTrace = 891750160,
     Desperation = 525593296,
 
     //energy exotic

--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -372,7 +372,6 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::DeadFall => Some(PerkOptionData::static_()),
         Perks::MoebiusQuiver => Some(PerkOptionData::static_()),
         Perks::Broadhead => Some(PerkOptionData::static_()),
-        Perks::HuntersTrace => Some(PerkOptionData::toggle()),
         Perks::Desperation => Some(PerkOptionData::toggle()),
 
         Perks::DragonShadow => Some(PerkOptionData::toggle()),


### PR DESCRIPTION
Got this from https://discord.com/channels/1044304864903168061/1161511179479433226
Can recreate by just going to the weapon and toggling on Hunter's Trace https://d2foundry.gg/w/1473821207?p=0,0,0,0,0&m=0&mw=0