### PR TITLE
fix: rapid fire shotgun reserves

### DIFF
--- a/src/perks/other_perks.rs
+++ b/src/perks/other_perks.rs
@@ -50,13 +50,16 @@ pub fn other_perks() {
         Perks::RapidFireFrame,
         Box::new(
             |_input: ModifierResponseInput| -> InventoryModifierResponse {
-                if _input.calc_data.weapon_type == &WeaponType::SNIPER {
-                    InventoryModifierResponse {
+                match *_input.calc_data.weapon_type {
+                    WeaponType::SNIPER => InventoryModifierResponse {
                         inv_scale: 1.3,
                         ..Default::default()
-                    }
-                } else {
-                    InventoryModifierResponse::default()
+                    },
+                    WeaponType::SHOTGUN => InventoryModifierResponse {
+                        inv_add: 8,
+                        ..Default::default()
+                    },
+                    _ => InventoryModifierResponse::default(),
                 }
             },
         ),


### PR DESCRIPTION
source: mossy
this is the actual fix, I realized that we were overwriting a trait that already existed (sniper rapid fire)
probably should make a way to detect we are doing that. with PHF or a runtime check? 
i just made a new PR because the previous one was based on an old branch
harm L