### PR TITLE
feat(wiki): init wiki with getting started page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ Please fork the [d2foundry/oracle_engine](https://github.com/d2foundry/oracle_en
 * add - new perks, functionality, etc
 * data - we had wrong data
 * feat - generally also dependent on the frontend/needs kat
+* wiki - anything in regards to the wiki 
 
 # Thank You!
 

--- a/docs/build.js.sample
+++ b/docs/build.js.sample
@@ -1,0 +1,53 @@
+const D2Calc = require('../pkg');
+
+const API_ROOT = "https://www.bungie.net/Platform/Destiny2/"
+const API_KEY = "<YOUR BUNGIE API KEY HERE>"
+const API_KEY_HEADER = {"X-API-Key": API_KEY}
+
+const WEAPON_STAT_HASHES = [
+    1591432999,
+    1345609583,
+    3614673599,
+    447667954,
+    943549884,
+    1931675084,
+    3871231066,
+    1240592695,
+    2715839340,
+    4188031367,
+    1842278586,
+    155624089,
+    2523465841,
+    3555269338
+]
+
+function getWeaponDefinition(entityHash) {
+    return fetch(API_ROOT + `Manifest/DestinyInventoryItemDefinition/${entityHash}/`, {headers: API_KEY_HEADER})
+        .then(response => response.json())
+}
+
+(async () => {
+    let hash = 1751893422
+    const weaponDef = await getWeaponDefinition(hash);
+    let weapon_dict = weaponDef.Response
+    if (weapon_dict["itemType"] != 3) {
+        throw new Error("Not a weapon")
+    }
+
+    let weapon_family = weapon_dict["itemSubType"]
+    let weapon_subfamily = weapon_dict["sockets"]["socketEntries"][0]["singleInitialItemHash"]
+    let dmg_type = weapon_dict["defaultDamageTypeHash"]
+    let weapon_ammo = weapon_dict["equippingBlock"]["ammoType"]
+    D2Calc.setWeapon(hash, weapon_family, weapon_subfamily, weapon_ammo, dmg_type)
+
+    let all_stats = new Map()
+    for (let stat of weapon_dict["investmentStats"]) {
+        if (WEAPON_STAT_HASHES.includes(stat["statTypeHash"])) {
+            all_stats.set(stat["statTypeHash"],stat["value"])
+        }
+    }
+    D2Calc.setStats(all_stats)
+    // weapon initialized
+    // put everything you are testing below this
+    console.log(D2Calc.stringifyWeapon())
+})();

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
 # Hello Guardian 
 
-Welcome to the Oracle Engine wiki! This page will cover how to run Oracle Engine locally with a helper node script, go into broad detail on lib.rs, and other common things you need to know about Oracle Engine.
+Welcome to the Oracle Engine wiki! This page will cover how to get any necessary prequisites, run the given sample script, and show how to change the weapon used in the script.
 
 ## Prerequisites 
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,36 @@
+# Hello Guardian 
+
+Welcome to the Oracle Engine wiki! This page will cover how to run Oracle Engine locally with a helper node script, go into broad detail on lib.rs, and other common things you need to know about Oracle Engine.
+
+## Prerequisites 
+
+* Rust v1.65 
+* Node v18  
+* WebAssembly (wasm-pack)
+* Bungie API key
+
+## Installing / Getting Prequisites
+
+On macOS and Linux you can use leverage [homebrew](https://brew.sh/) to install rust, node, and wasm-pack via brew install < name of app >
+
+You can get your own Bungie API key by registering an application on [Bungie's developer portal](https://www.bungie.net/en/Application)
+
+## Building Oracle Engine for NodeJS
+
+In order to test the changes you may want to make to Oracle Engine, you will have to build it for NodeJS. 
+
+```wasm-pack build --release --target nodejs```
+
+We have included a sample script in this wiki that you can use as a reference. Please remove the .sample file extension prior to use. In order to use the script, you will need to supply your own Bungie API key. Once you have done that, you can run the script via node. Make sure that the path for D2Calc points to wherever your oracle package is! With that in mind, running the following command should output Enigma's Draw as Oracle Engine defines it.
+
+```node docs/build.js```
+
+The reason why Enigma's Draw is shown is because its hash (1723380073) is what is used in the script. Go ahead and change this to whatever weapon you wish! Heres a few of my fav weapons in Destiny 2 to get you started.
+
+* 3871226707 // Mechabre
+* 578105049 // Oversoul Edict (Adept)
+* 235827225 // Eyasluna
+
+## Tweaking the Script to Test Things
+
+I know it's hard to believe that Enigma's Draw isn't the only weapon in Destiny 2 and even if it was... what about testing various perks on it? In order to do that, we need to leverage some of the functions inside of src/lib.rs which will be covered in a different wiki page.

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,3 @@
+Hello and welcome to the Oracle Engine wiki!
+
+Please stay tuned for more updates as they come! 

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,3 +1,7 @@
 Hello and welcome to the Oracle Engine wiki!
 
 Please stay tuned for more updates as they come! 
+
+Table of Contents
+
+* 00 - [Getting Started](./getting_started.md)


### PR DESCRIPTION
Starting to work on the wiki under the docs/ directory. Chose this route over using gh's built in wiki for a couple reasons but this is just easier to work with. I plan on writing more pages on lib.rs, weapon_formula structure, modifier responses, etc when I get the creative mindset and if this structure works... i'll probs add more sub directories as more pages get written but for now, it is what it is.

Also, added a new commit tag (wiki) to denote any changes that are strictly to these pages. Open to doing something like chore(wiki): as well. My thought was the merge commit for every subsequent wiki merge to be wiki: < your change here >