### PR TITLE
fix: under-over

### DIFF
--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -346,7 +346,7 @@ pub enum Perks {
     GutShot = 1365187766,
     Pugilist = 691659142,
     Slickdraw = 1821614984,
-    OverUnder = 1870851715,
+    UnderOver = 1870851715,
 
     //season 19 | year 5
     CascadePoint = 3751912585,

--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -261,7 +261,7 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::GutShot => Some(PerkOptionData::static_()),
         Perks::Pugilist => Some(PerkOptionData::toggle()),
         Perks::Slickdraw => Some(PerkOptionData::static_()),
-        Perks::OverUnder => Some(PerkOptionData::static_()),
+        Perks::UnderOver => Some(PerkOptionData::static_()),
 
         //season 19 | year 5
         Perks::CascadePoint => Some(PerkOptionData::toggle()),

--- a/src/perks/year_5_perks.rs
+++ b/src/perks/year_5_perks.rs
@@ -332,7 +332,7 @@ pub fn year_5_perks() {
         Perks::UnderOver,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let mut buff = 1.0_f64;
-            if _input.calc_data.has_overshield && _input.value > 0 {
+            if _input.calc_data.has_overshield {
                 buff += if _input.pvp { 0.2 } else { 1.25 };
                 if _input.is_enhanced {
                     buff *= 1.05;

--- a/src/perks/year_5_perks.rs
+++ b/src/perks/year_5_perks.rs
@@ -329,14 +329,14 @@ pub fn year_5_perks() {
     );
 
     add_dmr(
-        Perks::OverUnder,
+        Perks::UnderOver,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let mut buff = 1.0_f64;
-            if _input.calc_data.has_overshield {
-                buff += 0.2;
-            }
-            if _input.is_enhanced {
-                buff *= 1.05;
+            if _input.calc_data.has_overshield && _input.value > 0 {
+                buff += if _input.pvp { 0.2 } else { 1.25 };
+                if _input.is_enhanced {
+                    buff *= 1.05;
+                }
             }
             DamageModifierResponse {
                 impact_dmg_scale: buff,


### PR DESCRIPTION
- renamed perk from overUnder -> underOver
- nested the enhanced logic to avoid having two checks for has_overshield... but also i do hate nesting but im also sick sooooo 
- added in pve values as an if check for what mode the user is in
- need to verify if enhanced increases both pve and pvp benefits by 5%... not an issue currently since foundry doesnt support OS but we need to add this to our list of things to verify 