### PR TITLE
fix: make gutshot a toggle to represent non-ADS/ADS values

### DIFF
--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -258,7 +258,7 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::WellRounded => Some(PerkOptionData::stacking(2)),
 
         //season 18 | year 5
-        Perks::GutShot => Some(PerkOptionData::static_()),
+        Perks::GutShot => Some(PerkOptionData::toggle()),
         Perks::Pugilist => Some(PerkOptionData::toggle()),
         Perks::Slickdraw => Some(PerkOptionData::static_()),
         Perks::UnderOver => Some(PerkOptionData::static_()),

--- a/src/perks/year_5_perks.rs
+++ b/src/perks/year_5_perks.rs
@@ -111,6 +111,9 @@ pub fn year_5_perks() {
     add_dmr(
         Perks::GutShot,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
+            if _input.value == 0 {
+                return DamageModifierResponse::default();
+            }
             let high_weapons = [
                 WeaponType::AUTORIFLE,
                 WeaponType::HANDCANNON,


### PR DESCRIPTION
Sets up Gutshot as a Toggle instead of static, with 'off' representing non-ADS values and 'on' representing ADS values.

While it's a bit obtuse for the end user to try to figure out that toggling off/on correspond to non-ADS/ADS respectively, this is probably better UX than having the user add/remove the perk to see the changes between ADS states.