### PR TITLE
fix: move all default DamageModifierResponse values to use Default::default instead

### DIFF
--- a/src/perks/exotic_armor.rs
+++ b/src/perks/exotic_armor.rs
@@ -104,7 +104,7 @@ pub fn exotic_armor() {
             DamageModifierResponse {
                 impact_dmg_scale: modifier,
                 explosive_dmg_scale: modifier,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/exotic_perks.rs
+++ b/src/perks/exotic_perks.rs
@@ -44,7 +44,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_buff,
                 explosive_dmg_scale: damage_buff,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -137,7 +137,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_buff,
                 explosive_dmg_scale: damage_buff,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -178,8 +178,7 @@ pub fn exotic_perks() {
             };
             DamageModifierResponse {
                 crit_scale: crit_mult,
-                explosive_dmg_scale: 1.0,
-                impact_dmg_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -274,7 +273,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + (val as f64) * 0.1,
                 explosive_dmg_scale: 1.0 + (val as f64) * 0.1,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -289,7 +288,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_buff,
                 explosive_dmg_scale: damage_buff,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -304,7 +303,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_buff,
                 explosive_dmg_scale: damage_buff,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -411,6 +410,7 @@ pub fn exotic_perks() {
                 explosive_dmg_scale: 1.48,
                 impact_dmg_scale: 1.48,
                 crit_scale,
+                ..Default::default()
             }
         }),
     );
@@ -427,7 +427,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: dmg_mult,
                 explosive_dmg_scale: dmg_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -441,7 +441,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: dmg_mult,
                 explosive_dmg_scale: dmg_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -457,7 +457,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -493,6 +493,7 @@ pub fn exotic_perks() {
                 impact_dmg_scale: damage_mult,
                 explosive_dmg_scale: damage_mult,
                 crit_scale: crit_mult,
+                ..Default::default()
             }
         }),
     );
@@ -549,7 +550,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_mult,
                 explosive_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -684,6 +685,7 @@ pub fn exotic_perks() {
                 explosive_dmg_scale: damage_mult,
                 impact_dmg_scale: damage_mult,
                 crit_scale: crit_mult,
+                ..Default::default()
             }
         }),
     );
@@ -702,6 +704,7 @@ pub fn exotic_perks() {
                 explosive_dmg_scale: damage_mult,
                 impact_dmg_scale: damage_mult,
                 crit_scale: crit_mult,
+                ..Default::default()
             }
         }),
     );
@@ -723,7 +726,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 explosive_dmg_scale: damage_mult,
                 impact_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -740,7 +743,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 explosive_dmg_scale: damage_mult,
                 impact_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -753,7 +756,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 explosive_dmg_scale: 1.0 + damage_mult,
                 impact_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -773,7 +776,7 @@ pub fn exotic_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -822,10 +825,12 @@ pub fn exotic_perks() {
     add_dmr(
         Perks::FullStop,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
+            if _input.pvp {
+                return DamageModifierResponse::default()
+            }
             DamageModifierResponse {
-                explosive_dmg_scale: 1.0,
-                impact_dmg_scale: 1.0,
-                crit_scale: if !_input.pvp { 2.9 } else { 1.0 },
+                crit_scale: 2.9,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/lib.rs
+++ b/src/perks/lib.rs
@@ -143,6 +143,7 @@ impl<'a> CalculationInput<'a> {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct DamageModifierResponse {
     pub impact_dmg_scale: f64,

--- a/src/perks/meta_perks.rs
+++ b/src/perks/meta_perks.rs
@@ -62,6 +62,7 @@ pub fn meta_perks() {
                 crit_scale,
                 impact_dmg_scale: dmg_scale,
                 explosive_dmg_scale: dmg_scale,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/origin_perks.rs
+++ b/src/perks/origin_perks.rs
@@ -73,7 +73,7 @@ pub fn origin_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: buff,
                 explosive_dmg_scale: buff,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -177,7 +177,7 @@ pub fn origin_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_mult,
                 explosive_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/other_perks.rs
+++ b/src/perks/other_perks.rs
@@ -330,7 +330,7 @@ pub fn other_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_mult,
                 explosive_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -384,7 +384,7 @@ pub fn other_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_mult,
                 explosive_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -400,7 +400,7 @@ pub fn other_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_mult,
                 explosive_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -410,8 +410,7 @@ pub fn other_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             DamageModifierResponse {
                 impact_dmg_scale: 1.125,
-                explosive_dmg_scale: 1.0,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -422,7 +421,7 @@ pub fn other_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 0.75,
                 explosive_dmg_scale: 0.75,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -434,9 +433,8 @@ pub fn other_perks() {
                 && _input.calc_data.base_crit_mult < 1.15
             {
                 DamageModifierResponse {
-                    impact_dmg_scale: 1.0,
-                    explosive_dmg_scale: 1.0,
                     crit_scale: 0.92,
+                    ..Default::default()
                 }
             } else {
                 DamageModifierResponse::default()
@@ -482,7 +480,7 @@ pub fn other_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.02,
                 explosive_dmg_scale: 1.02,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/year_1_perks.rs
+++ b/src/perks/year_1_perks.rs
@@ -55,7 +55,7 @@ pub fn year_1_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: out_dmg_scale,
                 explosive_dmg_scale: out_dmg_scale,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -137,9 +137,8 @@ pub fn year_1_perks() {
                     crit_mult *= 0.95;
                 }
                 return DamageModifierResponse {
-                    impact_dmg_scale: 1.0,
-                    explosive_dmg_scale: 1.0,
                     crit_scale: crit_mult,
+                    ..Default::default()
                 };
             };
             DamageModifierResponse::default()
@@ -168,9 +167,8 @@ pub fn year_1_perks() {
                 DamageModifierResponse::default()
             } else {
                 DamageModifierResponse {
-                    impact_dmg_scale: 1.0,
                     explosive_dmg_scale: 1.3,
-                    crit_scale: 1.0,
+                    ..Default::default()
                 }
             }
         }),
@@ -197,9 +195,8 @@ pub fn year_1_perks() {
             } else {
                 // let damage_mult = ((1.0 /  _input.calc_data.base_crit_mult) * 0.15) + 1.0;
                 DamageModifierResponse {
-                    impact_dmg_scale: 1.0,
                     explosive_dmg_scale: 1.3,
-                    crit_scale: 1.0,
+                    ..Default::default()
                 }
             }
         }),
@@ -389,8 +386,7 @@ pub fn year_1_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             DamageModifierResponse {
                 impact_dmg_scale: 1.1,
-                explosive_dmg_scale: 1.0,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -599,7 +595,7 @@ pub fn year_1_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -615,7 +611,7 @@ pub fn year_1_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -631,7 +627,7 @@ pub fn year_1_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 - damage_mult,
                 explosive_dmg_scale: 1.0 - damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -716,7 +712,7 @@ pub fn year_1_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -855,6 +851,7 @@ pub fn year_1_perks() {
                 impact_dmg_scale: precision_body / lightweight_body,
                 explosive_dmg_scale: precision_body / lightweight_body,
                 crit_scale: precision_crit / lightweight_crit,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/year_2_perks.rs
+++ b/src/perks/year_2_perks.rs
@@ -50,9 +50,8 @@ pub fn year_2_perks() {
                 DamageModifierResponse::default()
             } else {
                 DamageModifierResponse {
-                    impact_dmg_scale: 1.0,
                     explosive_dmg_scale: 1.3,
-                    crit_scale: 1.0,
+                    ..Default::default()
                 }
             }
         }),
@@ -140,8 +139,7 @@ pub fn year_2_perks() {
             }
             DamageModifierResponse {
                 crit_scale: crit_mult,
-                explosive_dmg_scale: 1.0,
-                impact_dmg_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -172,7 +170,7 @@ pub fn year_2_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -273,7 +271,7 @@ pub fn year_2_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: damage_mult,
                 explosive_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -286,9 +284,8 @@ pub fn year_2_perks() {
                 damage_mult = 1.25;
             };
             DamageModifierResponse {
-                impact_dmg_scale: 1.0,
                 explosive_dmg_scale: damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -305,7 +302,7 @@ pub fn year_2_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + dmg_boost,
                 explosive_dmg_scale: 1.0 + dmg_boost,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -321,7 +318,7 @@ pub fn year_2_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -343,7 +340,7 @@ pub fn year_2_perks() {
             DamageModifierResponse {
                 explosive_dmg_scale: mult.0,
                 impact_dmg_scale: mult.1,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/year_3_perks.rs
+++ b/src/perks/year_3_perks.rs
@@ -132,9 +132,8 @@ pub fn year_3_perks() {
         Perks::LastingImpression,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             DamageModifierResponse {
-                impact_dmg_scale: 1.0,
                 explosive_dmg_scale: 1.25,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -159,7 +158,7 @@ pub fn year_3_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: buff,
                 explosive_dmg_scale: buff,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/year_4_perks.rs
+++ b/src/perks/year_4_perks.rs
@@ -30,7 +30,7 @@ pub fn year_4_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + dmg_boost,
                 explosive_dmg_scale: 1.0 + dmg_boost,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -90,7 +90,7 @@ pub fn year_4_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + dmg_boost,
                 explosive_dmg_scale: 1.0 + dmg_boost,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -238,7 +238,7 @@ pub fn year_4_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + dmg,
                 explosive_dmg_scale: 1.0 + dmg,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -439,7 +439,7 @@ pub fn year_4_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + dmg,
                 explosive_dmg_scale: 1.0 + dmg,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -482,7 +482,7 @@ pub fn year_4_perks() {
                 DamageModifierResponse {
                     impact_dmg_scale: 1.0 + damage_mult,
                     explosive_dmg_scale: 1.0 + damage_mult,
-                    crit_scale: 1.0,
+                    ..Default::default()
                 }
             } else {
                 DamageModifierResponse::default()
@@ -501,7 +501,7 @@ pub fn year_4_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.0 + damage_mult,
                 explosive_dmg_scale: 1.0 + damage_mult,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );

--- a/src/perks/year_5_perks.rs
+++ b/src/perks/year_5_perks.rs
@@ -77,7 +77,7 @@ pub fn year_5_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: dmg_boost,
                 explosive_dmg_scale: dmg_boost,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -136,6 +136,7 @@ pub fn year_5_perks() {
                 impact_dmg_scale: dmg_scale,
                 explosive_dmg_scale: dmg_scale,
                 crit_scale,
+                ..Default::default()
             }
         }),
     );
@@ -330,7 +331,7 @@ pub fn year_5_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: buff + 1.0,
                 explosive_dmg_scale: buff + 1.0,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -348,7 +349,7 @@ pub fn year_5_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: buff,
                 explosive_dmg_scale: buff,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -408,7 +409,7 @@ pub fn year_5_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: 1.30,
                 explosive_dmg_scale: 1.30,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );
@@ -537,7 +538,7 @@ pub fn year_5_perks() {
             DamageModifierResponse {
                 impact_dmg_scale: scalar,
                 explosive_dmg_scale: scalar,
-                crit_scale: 1.0,
+                ..Default::default()
             }
         }),
     );


### PR DESCRIPTION
This is in preparation for Melee damage handling from #105.

Any scalar here that previously used a value of '1.0' has been removed (to pick up defaults), and all DamageModifierResponses now specify `..Default::default()` so that any updates to the DamageModifierResponse struct will not require updating every single perk.

Add non_exhausive to DamageModifierResponse as it will have fields added in the near future
This should be removed once we expect no more fields to be added to the struct.
https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
This prevents clippy from flagging the use of default on fully-specified struct values.