### PR TITLE
Add Vorpal for Malfeasance Catalyst, add new Graviton Lance catalyst

### DIFF
--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -286,7 +286,7 @@ pub enum Perks {
     ClownCartridge = 2284787283,
     ElementalCapacitor = 3511092054,
     #[num_enum(alternatives = [
-        3547298847, // grav lance old cat
+        3547298847, // grav lance old cat, to be removed after UI update
         1620506139, // grav lance cat
         1234111636, // malf cat
     ])]

--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -286,7 +286,8 @@ pub enum Perks {
     ClownCartridge = 2284787283,
     ElementalCapacitor = 3511092054,
     #[num_enum(alternatives = [
-        3547298847, // grav lance cat
+        3547298847, // grav lance old cat
+        1620506139, // grav lance cat
         1234111636, // malf cat
     ])]
     Vorpal = 1546637391,

--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -285,7 +285,10 @@ pub enum Perks {
     //season 9 | year 3
     ClownCartridge = 2284787283,
     ElementalCapacitor = 3511092054,
-    #[num_enum(alternatives = [3547298847, ])] // grav lance cat
+    #[num_enum(alternatives = [
+        3547298847, // grav lance cat
+        1234111636, // malf cat
+    ])]
     Vorpal = 1546637391,
 
     //season 10 | year 3


### PR DESCRIPTION
Graviton Lance has 2 catalysts available to slot into its catalyst socket
https://www.light.gg/db/items/3628991658/graviton-lance/?p=,,,,3547298847
https://www.light.gg/db/items/3628991658/graviton-lance/?p=,,,,1620506139

The UI seems like it's only grabbing the first one available (or something), which was previously tied to the `Hidden Hand` perk. That catalyst isn't available in-game anymore, and we should update the UI to reflect the correct catalyst; this PR allows Vorpal to function on it with the new catalyst once the UI gets updated.