### PR TITLE
chore: Add helpers for standard damage modifiers + surge damage modifiers

### DIFF
--- a/src/perks/buff_perks.rs
+++ b/src/perks/buff_perks.rs
@@ -54,8 +54,6 @@ fn gbl_debuff(_cached_data: &mut HashMap<String, f64>, _desired_buff: f64) -> f6
     }
 }
 
-//surge mod dmr is in meta_perks.rs
-
 //
 // BUFFS
 //
@@ -64,11 +62,7 @@ pub fn buff_perks() {
         Perks::WellOfRadiance,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let buff = emp_buff(_input.cached_data, 1.25);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -80,11 +74,7 @@ pub fn buff_perks() {
             }
             let des_buff = if _input.pvp { 1.15 } else { 1.35 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -94,11 +84,7 @@ pub fn buff_perks() {
             let des_buff = if _input.pvp { 1.1 } else { 1.25 };
             let buff = emp_buff(_input.cached_data, des_buff);
             _input.cached_data.insert("radiant".to_string(), 1.0);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -109,11 +95,7 @@ pub fn buff_perks() {
                 return DamageModifierResponse::default();
             }
             let buff = surge_buff(_input.cached_data, _input.value, _input.pvp);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(buff)
         }),
     );
 
@@ -122,11 +104,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_buff = if _input.pvp { 1.35 } else { 1.4 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -135,11 +113,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_buff = if _input.pvp { 1.15 } else { 1.2 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -147,11 +121,7 @@ pub fn buff_perks() {
         Perks::WardOfDawn,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let buff = emp_buff(_input.cached_data, 1.25);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -160,11 +130,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_buff = if _input.pvp { 1.0 } else { 1.35 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -195,11 +161,7 @@ pub fn buff_perks() {
                 pve_values[clamp(_input.value, 0, 3) as usize]
             };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(buff)
         }),
     );
 
@@ -227,11 +189,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.075 } else { 1.15 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse {
-                impact_dmg_scale: debuff,
-                explosive_dmg_scale: debuff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(debuff)
         }),
     );
 
@@ -240,11 +198,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.5 } else { 1.3 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse {
-                impact_dmg_scale: debuff,
-                explosive_dmg_scale: debuff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(debuff)
         }),
     );
 
@@ -253,11 +207,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.5 } else { 1.3 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse {
-                impact_dmg_scale: debuff,
-                explosive_dmg_scale: debuff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(debuff)
         }),
     );
     add_dmr(
@@ -265,11 +215,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.5 } else { 1.3 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse {
-                impact_dmg_scale: debuff,
-                explosive_dmg_scale: debuff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(debuff)
         }),
     );
     add_dmr(
@@ -277,11 +223,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             if _input.value > 0 {
                 let debuff = gbl_debuff(_input.cached_data, 1.3);
-                DamageModifierResponse {
-                    impact_dmg_scale: debuff,
-                    explosive_dmg_scale: debuff,
-                    ..Default::default()
-                }
+                DamageModifierResponse::basic_dmg_mod(debuff)
             } else {
                 DamageModifierResponse::default()
             }
@@ -298,22 +240,14 @@ pub fn buff_perks() {
                 pve_values[clamp(_input.value, 0, 4) as usize]
             };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse {
-                impact_dmg_scale: debuff,
-                explosive_dmg_scale: debuff,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(debuff)
         }),
     );
     add_dmr(
         Perks::SurgeMod,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let damage_mod = surge_buff(_input.cached_data, _input.value, _input.pvp);
-            DamageModifierResponse {
-                explosive_dmg_scale: damage_mod,
-                impact_dmg_scale: damage_mod,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(damage_mod)
         }),
     );
     add_sbr(
@@ -335,11 +269,7 @@ pub fn buff_perks() {
         Perks::EternalWarrior,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let damage_mod = surge_buff(_input.cached_data, _input.value, _input.pvp);
-            DamageModifierResponse {
-                explosive_dmg_scale: damage_mod,
-                impact_dmg_scale: damage_mod,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(damage_mod)
         }),
     );
 
@@ -351,11 +281,7 @@ pub fn buff_perks() {
             } else {
                 1.0
             };
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(buff)
         }),
     );
     add_dmr(
@@ -370,11 +296,7 @@ pub fn buff_perks() {
             } else {
                 1.0
             };
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(buff)
         }),
     );
     add_dmr(
@@ -386,11 +308,7 @@ pub fn buff_perks() {
 
             let buff = surge_buff(_input.cached_data, 2, _input.pvp);
 
-            DamageModifierResponse {
-                impact_dmg_scale: buff,
-                explosive_dmg_scale: buff,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(buff)
         }),
     );
     add_dmr(
@@ -400,11 +318,7 @@ pub fn buff_perks() {
                 return DamageModifierResponse::default();
             }
             let mult = surge_buff(_input.cached_data, 4, _input.pvp);
-            DamageModifierResponse {
-                impact_dmg_scale: mult,
-                explosive_dmg_scale: mult,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(mult)
         }),
     );
     add_dmr(
@@ -414,11 +328,7 @@ pub fn buff_perks() {
                 return DamageModifierResponse::default();
             }
             let mult = surge_buff(_input.cached_data, 4, _input.pvp);
-            DamageModifierResponse {
-                impact_dmg_scale: mult,
-                explosive_dmg_scale: mult,
-                ..Default::default()
-            }
+            DamageModifierResponse::surge_mod(mult)
         }),
     );
     add_dmr(

--- a/src/perks/buff_perks.rs
+++ b/src/perks/buff_perks.rs
@@ -62,7 +62,7 @@ pub fn buff_perks() {
         Perks::WellOfRadiance,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let buff = emp_buff(_input.cached_data, 1.25);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -74,7 +74,7 @@ pub fn buff_perks() {
             }
             let des_buff = if _input.pvp { 1.15 } else { 1.35 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -84,7 +84,7 @@ pub fn buff_perks() {
             let des_buff = if _input.pvp { 1.1 } else { 1.25 };
             let buff = emp_buff(_input.cached_data, des_buff);
             _input.cached_data.insert("radiant".to_string(), 1.0);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -95,7 +95,7 @@ pub fn buff_perks() {
                 return DamageModifierResponse::default();
             }
             let buff = surge_buff(_input.cached_data, _input.value, _input.pvp);
-            DamageModifierResponse::surge_mod(buff)
+            DamageModifierResponse::surge_buff(buff)
         }),
     );
 
@@ -104,7 +104,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_buff = if _input.pvp { 1.35 } else { 1.4 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -113,7 +113,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_buff = if _input.pvp { 1.15 } else { 1.2 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -121,7 +121,7 @@ pub fn buff_perks() {
         Perks::WardOfDawn,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let buff = emp_buff(_input.cached_data, 1.25);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -130,7 +130,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_buff = if _input.pvp { 1.0 } else { 1.35 };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -161,7 +161,7 @@ pub fn buff_perks() {
                 pve_values[clamp(_input.value, 0, 3) as usize]
             };
             let buff = emp_buff(_input.cached_data, des_buff);
-            DamageModifierResponse::basic_dmg_mod(buff)
+            DamageModifierResponse::basic_dmg_buff(buff)
         }),
     );
 
@@ -189,7 +189,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.075 } else { 1.15 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse::basic_dmg_mod(debuff)
+            DamageModifierResponse::basic_dmg_buff(debuff)
         }),
     );
 
@@ -198,7 +198,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.5 } else { 1.3 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse::basic_dmg_mod(debuff)
+            DamageModifierResponse::basic_dmg_buff(debuff)
         }),
     );
 
@@ -207,7 +207,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.5 } else { 1.3 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse::basic_dmg_mod(debuff)
+            DamageModifierResponse::basic_dmg_buff(debuff)
         }),
     );
     add_dmr(
@@ -215,7 +215,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let des_debuff = if _input.pvp { 1.5 } else { 1.3 };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse::basic_dmg_mod(debuff)
+            DamageModifierResponse::basic_dmg_buff(debuff)
         }),
     );
     add_dmr(
@@ -223,7 +223,7 @@ pub fn buff_perks() {
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             if _input.value > 0 {
                 let debuff = gbl_debuff(_input.cached_data, 1.3);
-                DamageModifierResponse::basic_dmg_mod(debuff)
+                DamageModifierResponse::basic_dmg_buff(debuff)
             } else {
                 DamageModifierResponse::default()
             }
@@ -240,14 +240,14 @@ pub fn buff_perks() {
                 pve_values[clamp(_input.value, 0, 4) as usize]
             };
             let debuff = gbl_debuff(_input.cached_data, des_debuff);
-            DamageModifierResponse::basic_dmg_mod(debuff)
+            DamageModifierResponse::basic_dmg_buff(debuff)
         }),
     );
     add_dmr(
         Perks::SurgeMod,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let damage_mod = surge_buff(_input.cached_data, _input.value, _input.pvp);
-            DamageModifierResponse::surge_mod(damage_mod)
+            DamageModifierResponse::surge_buff(damage_mod)
         }),
     );
     add_sbr(
@@ -269,7 +269,7 @@ pub fn buff_perks() {
         Perks::EternalWarrior,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             let damage_mod = surge_buff(_input.cached_data, _input.value, _input.pvp);
-            DamageModifierResponse::surge_mod(damage_mod)
+            DamageModifierResponse::surge_buff(damage_mod)
         }),
     );
 
@@ -281,7 +281,7 @@ pub fn buff_perks() {
             } else {
                 1.0
             };
-            DamageModifierResponse::surge_mod(buff)
+            DamageModifierResponse::surge_buff(buff)
         }),
     );
     add_dmr(
@@ -296,7 +296,7 @@ pub fn buff_perks() {
             } else {
                 1.0
             };
-            DamageModifierResponse::surge_mod(buff)
+            DamageModifierResponse::surge_buff(buff)
         }),
     );
     add_dmr(
@@ -308,7 +308,7 @@ pub fn buff_perks() {
 
             let buff = surge_buff(_input.cached_data, 2, _input.pvp);
 
-            DamageModifierResponse::surge_mod(buff)
+            DamageModifierResponse::surge_buff(buff)
         }),
     );
     add_dmr(
@@ -318,7 +318,7 @@ pub fn buff_perks() {
                 return DamageModifierResponse::default();
             }
             let mult = surge_buff(_input.cached_data, 4, _input.pvp);
-            DamageModifierResponse::surge_mod(mult)
+            DamageModifierResponse::surge_buff(mult)
         }),
     );
     add_dmr(
@@ -328,7 +328,7 @@ pub fn buff_perks() {
                 return DamageModifierResponse::default();
             }
             let mult = surge_buff(_input.cached_data, 4, _input.pvp);
-            DamageModifierResponse::surge_mod(mult)
+            DamageModifierResponse::surge_buff(mult)
         }),
     );
     add_dmr(

--- a/src/perks/exotic_armor.rs
+++ b/src/perks/exotic_armor.rs
@@ -101,11 +101,7 @@ pub fn exotic_armor() {
                 return DamageModifierResponse::default();
             }
             let modifier = 1.0 + (0.3 - health_percent);
-            DamageModifierResponse {
-                impact_dmg_scale: modifier,
-                explosive_dmg_scale: modifier,
-                ..Default::default()
-            }
+            DamageModifierResponse::basic_dmg_mod(modifier)
         }),
     );
 

--- a/src/perks/exotic_armor.rs
+++ b/src/perks/exotic_armor.rs
@@ -101,7 +101,7 @@ pub fn exotic_armor() {
                 return DamageModifierResponse::default();
             }
             let modifier = 1.0 + (0.3 - health_percent);
-            DamageModifierResponse::basic_dmg_mod(modifier)
+            DamageModifierResponse::basic_dmg_buff(modifier)
         }),
     );
 

--- a/src/perks/lib.rs
+++ b/src/perks/lib.rs
@@ -161,7 +161,7 @@ impl Default for DamageModifierResponse {
 }
 impl DamageModifierResponse {
     // damage modifier that affects all damage types
-    pub fn basic_dmg_mod(modifier: f64) -> Self {
+    pub fn basic_dmg_buff(modifier: f64) -> Self {
         Self {
             impact_dmg_scale: modifier,
             explosive_dmg_scale: modifier,
@@ -170,7 +170,7 @@ impl DamageModifierResponse {
         }
     }
     // damage modifier that does not affect melee damage
-    pub fn surge_mod(modifier: f64) -> Self {
+    pub fn surge_buff(modifier: f64) -> Self {
         Self {
             impact_dmg_scale: modifier,
             explosive_dmg_scale: modifier,

--- a/src/perks/lib.rs
+++ b/src/perks/lib.rs
@@ -159,6 +159,25 @@ impl Default for DamageModifierResponse {
         }
     }
 }
+impl DamageModifierResponse {
+    // damage modifier that affects all damage types
+    pub fn basic_dmg_mod(modifier: f64) -> Self {
+        Self {
+            impact_dmg_scale: modifier,
+            explosive_dmg_scale: modifier,
+            // pending: melee_dmg_scale
+            ..Default::default()
+        }
+    }
+    // damage modifier that does not affect melee damage
+    pub fn surge_mod(modifier: f64) -> Self {
+        Self {
+            impact_dmg_scale: modifier,
+            explosive_dmg_scale: modifier,
+            ..Default::default()
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExtraDamageResponse {


### PR DESCRIPTION
basic_dmg_mod buffs impact, explosive, and melee (melee is pending the Glaive impl, which will add the melee_dmg_scale field)
surge_mod buffs just impact and explosive

As a general rule of thumb, empower buffs and weaken effects use basic_dmg_mod and surge buffs use surge_mod (ofc).

I pulled this out of #105 to clean that PR up a bit.