### PR TITLE
add: MIDA Multi-Tool's No Distractions

### DIFF
--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -277,6 +277,11 @@ pub enum Perks {
     UnderDog = 205890336,
     ExplosiveLight = 3194351027,
     EyeOfTheStorm = 699525795,
+    #[num_enum(alternatives = [
+        2162261876, // mida old cat
+        800074992,  // mida dummy cat
+        3466057365, // mida cat
+    ])]
     NoDistractions = 2866798147,
 
     //season 8 | year 3


### PR DESCRIPTION
This adds all 3 of the relevant item hashes, so that no matter which one consumers pick up, the trait gets applied.

As with all old-catalyst weapons, the item in the API comes with 2 options for the socket, an "Upgrade Masterwork" and dummy catalyst item. The real catalyst can only be found via the perk category of the two other options, and will be available from https://github.com/DestinyItemManager/d2-additional-info/pull/603 once that's ready.