### PR TITLE
remove: Sleeper Catalyst

### DIFF
--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -469,7 +469,6 @@ pub enum Perks {
     WhisperCatalyst = 1340292993,
     DarkDescent = 3333994164,
     TargetAquired = 939227542,
-    SleeperCatalyst = 2142466730,
     TractorCannon = 1210807262,
     MarksmanSights = 1408087975,
 

--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -341,7 +341,6 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::SurosLegacy => Some(PerkOptionData::static_()),
         Perks::SpinningUp => Some(PerkOptionData::stacking(2)),
         Perks::DarkDescent => Some(PerkOptionData::toggle()),
-        Perks::SleeperCatalyst => Some(PerkOptionData::static_()),
         Perks::TargetAquired => Some(PerkOptionData::toggle()),
         Perks::RatPack => Some(PerkOptionData::stacking_min(5, 1)),
         Perks::HuntersTrance => Some(PerkOptionData::static_()),


### PR DESCRIPTION
The catalyst item itself already sets the relevant investmentStats for the charge time (and oddly enough, skips the reserves since base reserves were buffed), so defining it here is not necessary.

See: https://data.destinysets.com/i/InventoryItem:136852797 (and old one at https://data.destinysets.com/i/InventoryItem:3386680334 )