### PR TITLE
use reqwest::blocking::Client with no timeout where the default 30s might not be enough

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -478,7 +478,7 @@ fn construct_enhance_perk_mapping(formula_file: &mut File, cached: &mut CachedBu
 
                 // build a blocking client with a 90s timeout to prevent dl failures due to poverty
                 if let Ok(client) = reqwest::blocking::Client::builder()
-                    .timeout(std::time::Duration::from_secs(90))
+                    .timeout(None)
                     .build() {
                     item_data_raw = client.get(format!(
                         "https://www.bungie.net{}",


### PR DESCRIPTION
according to [request::blocking::get() docs](https://docs.rs/reqwest/latest/reqwest/blocking/fn.get.html), the request will fail if the download takes longer than 30s.

this PR implements a basic `reqwest::blocking::Client` with `timeout=None` for this request in particular

fixes #126 

