### PR TITLE
add: in-flight compensator

### DIFF
--- a/build_resources/cached_build.ron
+++ b/build_resources/cached_build.ron
@@ -1,5 +1,5 @@
 (
-    last_manifest_version: "227476.24.08.14.1730-2-bnet.56577",
+    last_manifest_version: "227664.24.08.21.1730-3-bnet.56627",
     dim_perk_mappings: [
         (23371658, 2551157718),
         (64332393, 2428997981),

--- a/src/perks/meta_perks.rs
+++ b/src/perks/meta_perks.rs
@@ -361,4 +361,18 @@ pub fn meta_perks() {
             }
         }),
     );
+    add_sbr(
+        Perks::InFlightCompensatorMod,
+        Box::new(|_input: ModifierResponseInput| -> HashMap<u32, i32> {
+            let mut stats = HashMap::new();
+            let buff = match _input.value {
+                0 => 0,
+                1 => 15,
+                2 => 25,
+                3.. => 30,
+            };
+            stats.insert(StatHashes::AIRBORNE.into(), buff);
+            stats
+        }),
+    )
 }

--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -115,6 +115,7 @@ pub enum Perks {
     LoaderMod = 1004,
     UnflinchingMod = 1005,
     SurgeMod = 1006,
+    InFlightCompensatorMod = 1007,
     LucentBlades = 531057500,
     DragonShadow = 593361144,
     OphidianAspect = 1147638875,

--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -372,6 +372,7 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::TargetingMod => Some(PerkOptionData::stacking(3)),
         Perks::UnflinchingMod => Some(PerkOptionData::stacking(3)),
         Perks::SurgeMod => Some(PerkOptionData::stacking(3)),
+        Perks::InFlightCompensatorMod => Some(PerkOptionData::stacking(3)),
         Perks::LucentBlades => Some(PerkOptionData::stacking(3)),
         Perks::OnYourMark => Some(PerkOptionData::stacking(3)),
         Perks::Frequency => Some(PerkOptionData::toggle()),


### PR DESCRIPTION
  InFlightCompensator = 1007 
  
  {
    hash: ArmorMods.InFlightCompensator,
    label: "In-Flight Compensator",
    iconSrc:
      "https://www.bungie.net/common/destiny2_content/icons/c2c0994873f7f0cb6d1a3c5369618da3.png",
    subtitle: "Helmet Armor Mod",
  },
  
  