### PR TITLE
add: Burning Fists (Wormgod Caress) weapon damage scalars

### DIFF
--- a/src/perks/buff_perks.rs
+++ b/src/perks/buff_perks.rs
@@ -398,4 +398,30 @@ pub fn buff_perks() {
             }
         }),
     );
+    add_dmr(
+        Perks::BurningFists,
+        Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
+            if _input.value == 0 {
+                return DamageModifierResponse::default();
+            }
+            let buffs = match _input.value {
+                1 => (1.0, 1.0),
+                2 => (1.2, 1.0),
+                3 => (1.25, 1.2),
+                4 => (1.3, 1.25),
+                5 => (1.35, 1.25),
+                _ => (1.35, 1.25)
+            };
+            let weapon_buff = if _input.pvp {
+                emp_buff(_input.cached_data, buffs.1)
+            } else {
+                emp_buff(_input.cached_data, buffs.0)
+            };
+            DamageModifierResponse {
+                impact_dmg_scale: weapon_buff,
+                explosive_dmg_scale: weapon_buff,
+                ..Default::default()
+            }
+        }),
+    );
 }

--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -152,6 +152,7 @@ pub enum Perks {
     TritonVice = 187957397,
     GlacialGuard = 185514250,
     DoomFang = 1155472387,
+    BurningFists = 384759955,
 
     //parts
     ImpactCasing = 3796465595,

--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -450,6 +450,7 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::StringTheory => Some(PerkOptionData::static_()),
         Perks::Judgment => Some(PerkOptionData::toggle()),
         Perks::DoomFang => Some(PerkOptionData::stacking(4)),
+        Perks::BurningFists => Some(PerkOptionData::stacking(5)),
 
         //misc
         Perks::UmbralSharpening => Some(PerkOptionData::stacking(5)),


### PR DESCRIPTION
Based on:
```
Damage Buff at 1|2|3|4|5 Stacks:
• Melee: 55%|110%|165%|220%|275%
• Glaive Melee: 40%|80%|120%|160%|200%
• Weapon, PVE : 0%|20%|25%|30%|35%
• Weapon, PVP : 0%|0%|20%|25%|25%
```

Melee will be included during Glaive handling, but I figured it's not worth keeping the weapon damage locked in Glaive PR jail.