### PR TITLE
Swap out Noble Rounds for Blessing of the Sky

### DIFF
--- a/src/perks/buff_perks.rs
+++ b/src/perks/buff_perks.rs
@@ -67,7 +67,7 @@ pub fn buff_perks() {
     );
 
     add_dmr(
-        Perks::NobleRounds,
+        Perks::BlessingOfTheSky,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
             if _input.value == 0 {
                 return DamageModifierResponse::default();

--- a/src/perks/exotic_armor.rs
+++ b/src/perks/exotic_armor.rs
@@ -408,7 +408,7 @@ pub fn exotic_armor() {
         Box::new(
             |_input: ModifierResponseInput| -> HashMap<BungieHash, StatBump> {
                 let mut stats = HashMap::new();
-                if _input.calc_data.intrinsic_hash == 2144092201 {
+                if _input.calc_data.intrinsic_hash == Perks::NobleRounds.into() {
                     //Lumina
                     stats.insert(StatHashes::AIRBORNE.into(), 30);
                 };

--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -471,6 +471,7 @@ pub enum Perks {
     RideTheBull = 630329983,
     HuntersTrance = 383825919,
     NobleRounds = 2144092201,
+    BlessingOfTheSky = 743139589,
     StormAndStress = 2238035098,
     Roadborn = 1658733671,
     MarkovChain = 2814973067,

--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -366,7 +366,7 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::RatPack => Some(PerkOptionData::stacking_min(5, 1)),
         Perks::HuntersTrance => Some(PerkOptionData::static_()),
         Perks::RideTheBull => Some(PerkOptionData::stacking(2)),
-        Perks::NobleRounds => Some(PerkOptionData::toggle()),
+        Perks::BlessingOfTheSky => Some(PerkOptionData::toggle()),
         Perks::MementoMori => Some(PerkOptionData::toggle()),
         Perks::TractorCannon => Some(PerkOptionData::static_()),
         Perks::HarmonicLaser => Some(PerkOptionData::stacking(2)),


### PR DESCRIPTION
The secondary trait grants the damage bonus, so using it here.
UI may need to be updated to hook it up to the buff like Noble Rounds currently does (toggling Noble Rounds also toggles Blessing of the Sky in UI currently).

Also use perk def.into() for NobleRounds instead of magic numbers where it's used