### PR TITLE
fix: divinity intrinsic typo, use perk def.into() instead of magic number

### DIFF
--- a/src/perks/exotic_perks.rs
+++ b/src/perks/exotic_perks.rs
@@ -1325,21 +1325,21 @@ pub fn exotic_perks() {
         }),
     );
     add_dmr(
-        Perks::Judgement,
+        Perks::Judgment,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
-            const JUDGEMENT_HASH: u32 = 1797707170;
+            const JUDGMENT_HASH: u32 = Perks::Judgment.into();
 
             let hits_needed = if _input.pvp { 5 } else { 14 };
 
             if _input.calc_data.shots_fired_this_mag < (hits_needed as f64)
-                && _input.calc_data.intrinsic_hash != JUDGEMENT_HASH
+                && _input.calc_data.intrinsic_hash != JUDGMENT_HASH
                 && _input.value == 0
             {
                 return DamageModifierResponse::default();
             }
 
             let buff = match (_input.calc_data.intrinsic_hash, _input.pvp) {
-                (JUDGEMENT_HASH, _) | (_, true) => 1.3,
+                (JUDGMENT_HASH, _) | (_, true) => 1.3,
                 (_, false) => 1.15,
             };
 

--- a/src/perks/exotic_perks.rs
+++ b/src/perks/exotic_perks.rs
@@ -1327,19 +1327,17 @@ pub fn exotic_perks() {
     add_dmr(
         Perks::Judgment,
         Box::new(|_input: ModifierResponseInput| -> DamageModifierResponse {
-            const JUDGMENT_HASH: u32 = Perks::Judgment.into();
-
             let hits_needed = if _input.pvp { 5 } else { 14 };
 
             if _input.calc_data.shots_fired_this_mag < (hits_needed as f64)
-                && _input.calc_data.intrinsic_hash != JUDGMENT_HASH
+                && _input.calc_data.intrinsic_hash != Perks::Judgment.into()
                 && _input.value == 0
             {
                 return DamageModifierResponse::default();
             }
 
-            let buff = match (_input.calc_data.intrinsic_hash, _input.pvp) {
-                (JUDGMENT_HASH, _) | (_, true) => 1.3,
+            let buff = match (_input.calc_data.intrinsic_hash.into(), _input.pvp) {
+                (Perks::Judgment, _) | (_, true) => 1.3,
                 (_, false) => 1.15,
             };
 

--- a/src/perks/mod.rs
+++ b/src/perks/mod.rs
@@ -516,7 +516,7 @@ pub enum Perks {
     InverseRelationship = 1833111001,
     Spindle = 1180907940,
     TheRightChoice = 34498892,
-    Judgement = 1797707170,
+    Judgment = 1797707170,
     TempestCascade = 1208312843,
 
     //heavy exotic

--- a/src/perks/perk_options_handler.rs
+++ b/src/perks/perk_options_handler.rs
@@ -448,7 +448,7 @@ fn hash_to_perk_option_data(_hash: u32) -> Option<PerkOptionData> {
         Perks::GlacialGuard => Some(PerkOptionData::toggle()),
         Perks::PickYourPoison => Some(PerkOptionData::options(["ADS", "Hip-Fire"].to_vec())),
         Perks::StringTheory => Some(PerkOptionData::static_()),
-        Perks::Judgement => Some(PerkOptionData::toggle()),
+        Perks::Judgment => Some(PerkOptionData::toggle()),
         Perks::DoomFang => Some(PerkOptionData::stacking(4)),
 
         //misc


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a765b322-f019-4518-a921-ae6448e360d4)
